### PR TITLE
Add vitest tests and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ pnpm dev
 bun dev
 ```
 
+## Running tests
+
+Install dependencies and execute the test suite with:
+
+```bash
+yarn install
+yarn test
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/components/Table.test.tsx
+++ b/components/Table.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Table, TableColumn, TableFilter, TableSearch } from './Table';
+import '@testing-library/jest-dom';
+
+type Row = { id: number; name: string };
+
+const columns: TableColumn<Row>[] = [
+  { key: 'id', header: 'ID' },
+  { key: 'name', header: 'Name' },
+];
+
+const data: Row[] = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+];
+
+describe('Table component', () => {
+  it('renders headers and rows', () => {
+    render(<Table columns={columns} data={data} />);
+    expect(screen.getByText('ID')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('handles search input', () => {
+    const search: TableSearch = { value: '', onChange: vi.fn() };
+    render(<Table columns={columns} data={data} search={search} />);
+    const input = screen.getByPlaceholderText('جستجو...');
+    fireEvent.change(input, { target: { value: 'Al' } });
+    expect(search.onChange).toHaveBeenCalledWith('Al');
+  });
+
+  it('handles filter dropdown', () => {
+    const filter: TableFilter = {
+      key: 'name',
+      label: 'Name',
+      value: '',
+      onChange: vi.fn(),
+      options: [
+        { value: 'Alice', label: 'Alice' },
+        { value: 'Bob', label: 'Bob' },
+      ],
+    };
+    render(<Table columns={columns} data={data} filters={[filter]} />);
+    fireEvent.click(screen.getByText('Name'));
+    fireEvent.click(screen.getByText('Alice'));
+    expect(filter.onChange).toHaveBeenCalledWith('Alice');
+  });
+
+  it('calls onRowClick when row clicked', () => {
+    const onRowClick = vi.fn();
+    render(<Table columns={columns} data={data} onRowClick={onRowClick} />);
+    fireEvent.click(screen.getByText('Alice'));
+    expect(onRowClick).toHaveBeenCalledWith(data[0], 0);
+  });
+});

--- a/lib/hooks/useApi.test.ts
+++ b/lib/hooks/useApi.test.ts
@@ -1,0 +1,47 @@
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useApi, useApiMutation } from './useApi';
+import axios from 'axios';
+
+vi.mock('axios');
+
+const getMock = vi.fn(() => Promise.resolve({ data: 'get' }));
+const postMock = vi.fn(() => Promise.resolve({ data: 'post' }));
+
+(axios as unknown as { create: any }).create = vi.fn(() => ({
+  get: getMock,
+  post: postMock,
+  put: postMock,
+  patch: postMock,
+  delete: postMock,
+}));
+
+const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const client = new QueryClient();
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+};
+
+describe('useApi', () => {
+  it('calls axios.get with provided url', async () => {
+    renderHook(() => useApi('users', '/users'), { wrapper });
+    expect(getMock).toHaveBeenCalledWith('/users');
+  });
+});
+
+describe('useApiMutation', () => {
+  it('calls axios.post on mutate', async () => {
+    const { result } = renderHook(() => useApiMutation('/users', 'POST'), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ url: '/users', body: { name: 'A' } });
+    });
+    expect(postMock).toHaveBeenCalledWith('/users', { name: 'A' });
+  });
+
+  it('calls axios.get when method is GET', async () => {
+    const { result } = renderHook(() => useApiMutation('/users', 'GET'), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ url: '/users', params: { q: 1 } });
+    });
+    expect(getMock).toHaveBeenCalledWith('/users', { params: { q: 1 } });
+  });
+});

--- a/lib/store.test.ts
+++ b/lib/store.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react';
+import { useCounterStore } from './store';
+
+describe('useCounterStore', () => {
+  it('increments count', () => {
+    const { result } = renderHook(() => useCounterStore());
+    act(() => {
+      result.current.increase();
+    });
+    expect(result.current.count).toBe(1);
+  });
+
+  it('decrements count', () => {
+    const { result } = renderHook(() => useCounterStore());
+    act(() => {
+      result.current.decrease();
+    });
+    expect(result.current.count).toBe(-1);
+  });
+
+  it('resets count', () => {
+    const { result } = renderHook(() => useCounterStore());
+    act(() => {
+      result.current.increase();
+      result.current.reset();
+    });
+    expect(result.current.count).toBe(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "husky install",
-    "lint-staged": "lint-staged"
+    "lint-staged": "lint-staged",
+    "test": "vitest"
   },
   "lint-staged": {
     "**/*.(ts|tsx)": "yarn tsc --noEmit",
@@ -58,6 +59,11 @@
     "storybook": "9.0.16",
     "tailwindcss": "^4",
     "typescript": "^5.8.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite-tsconfig-paths": "^5.1.4",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- configure vitest with React and tsconfig paths
- add test script and testing libraries
- create unit tests for Table component, API hooks and store
- document how to run the tests

## Testing
- `yarn install` *(fails: RequestError 403)*
- `yarn test` *(fails: package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68761a500bb0833183aa810b305d071d